### PR TITLE
Radioactive Waste

### DIFF
--- a/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Medical/Afflictions.xml
+++ b/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Medical/Afflictions.xml
@@ -251,7 +251,7 @@
     <Effect minstrength="0" maxstrength="100" strengthchange="-200">
       <StatusEffect target="Character" targetlimbs="LeftHand,RightHand">
         <Affliction identifier="burn" amount="2.5" />
-        <sound file="%ModDir%/Content/Items/Medical/fleshburn.ogg" type="OnUse" range="500.0" loop="true" volume="1" />
+        <sound file="%ModDir%/Content/Items/Medical/fleshburn.ogg" type="OnUse" range="250.0" loop="true" volume="0.8" dontmuffle="true" />
       </StatusEffect>
     </Effect>
     <icon texture="%ModDir%/Content/UI/HazardousIconsAtlas.png" sourcerect="384,0,128,128" color="139,60,42,255" origin="0,0" />

--- a/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Misc/containers.xml
+++ b/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Misc/containers.xml
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Items>
-  <Item name="" identifier="fuelcrate" tags="crate,rodstorage,hazardcontainement" description="" scale="0.5" linkable="true" pickdistance="150" impactsoundtag="impact_metal_heavy">
-    <Price baseprice="200" displaynonempty="true">
+
+  <Item name="" identifier="fueltransportcylinder" tags="mediumitem,mobilecontainer,tool,hazardcontainement" description="" scale="0.5" linkable="true" pickdistance="150" impactsoundtag="impact_metal_heavy">
+    <PreferredContainer primary="reactorcab" minamount="1" maxamount="1" spawnprobability="1" />
+    <Price baseprice="150">
       <Price storeidentifier="merchantoutpost" sold="false" />
       <Price storeidentifier="merchantcity" minavailable="1" />
       <Price storeidentifier="merchantresearch" sold="false" multiplier="1.25" />
@@ -9,64 +11,97 @@
       <Price storeidentifier="merchantmine"  multiplier="1.25" />
       <Price storeidentifier="merchantengineering" multiplier="1.4" minavailable="2" />
     </Price>
-    <Deconstruct time="10">
-      <Item identifier="titaniumaluminiumalloy" />
-      <Item identifier="titaniumaluminiumalloy" />
+    <Deconstruct time="15">
+      <Item identifier="titanium" />
       <Item identifier="lead" />
       <Item identifier="rubber" />
     </Deconstruct>
-    <Fabricate suitablefabricators="fabricator" requiredtime="15">
+    <Fabricate suitablefabricators="fabricator" requiredtime="30">
       <RequiredSkill identifier="mechanical" level="25" />
       <RequiredItem identifier="titaniumaluminiumalloy" />
-      <Item identifier="titaniumaluminiumalloy" />
       <RequiredItem identifier="lead" />
+      <RequiredItem identifier="rubber" />
+    </Fabricate>
+    <Sprite texture="%ModDir%/Content/Items/Misc/RodCylinderSpritesheet.png" depth="0.55" sourcerect="0,32,116,32" origin="0.5,0.5" />
+    <InventoryIcon texture="%ModDir%/Content/Items/Misc/RodCylinderInvSpritesheet.png" sourcerect="0,0,64,64" origin="0.5,0.5" />
+    <Body width="215" height="30" density="30" />
+    <Holdable slots="RightHand,LeftHand" holdpos="0,-50" handle1="-10,0" handle2="10,0" aimable="false" msg="ItemMsgPickUpUse" canbeselected="false" canbepicked="true" pickkey="Select">
+      <StatusEffect type="OnContained" target="Character" SpeedMultiplier="0.95" setvalue="true" />
+    </Holdable>
+    <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Use">
+      <sprite name="Rod storage worn" texture="%ModDir%/Content/Items/Misc/rodstoragecylinder.png" canbehiddenbyotherwearables="false" rotation="90" inheritlimbdepth="false" depth="0.6" sourcerect="0,0,130,101" origin="0.5,0.6" limb="Torso" ignorelimbscale="true" scale="0.6" />
+    </Wearable>
+    <!-- Only accept fuel rods -->
+    <ItemContainer autofill="False" hideitems="true" drawinventory="true" capacity="1" slotsperrow="1" maxstacksize="1" canbeselected="true" msg="ItemMsgInteractSelect" keepopenwhenequipped="false" movableframe="false">
+      <Containable items="fuelrod,thoriumfuelrod,fuelrod_active,thoriumfuelrod_active,fulguriumfuelrod,fulguriumfuelrodvolatile,ekutility_incendiumfuelrod,depletedfuel" />
+    </ItemContainer>
+  </Item>
+
+  <Item name="" identifier="fuelcrate" tags="crate,rodstorage,hazardcontainement" description="" scale="0.5" linkable="true" pickdistance="150" impactsoundtag="impact_metal_heavy">
+    <Price baseprice="400" displaynonempty="true">
+      <Price storeidentifier="merchantoutpost" sold="false" />
+      <Price storeidentifier="merchantcity" minavailable="1" />
+      <Price storeidentifier="merchantresearch" sold="false" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" sold="false" multiplier="1.25" />
+      <Price storeidentifier="merchantmine"  multiplier="1.25" />
+      <Price storeidentifier="merchantengineering" multiplier="1.4" minavailable="2" />
+    </Price>
+    <Deconstruct time="20">
+      <Item identifier="titaniumaluminiumalloy" />
+      <Item identifier="lead" amount="2" />
+      <Item identifier="rubber" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="60">
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem identifier="titaniumaluminiumalloy" amount="2" />
+      <RequiredItem identifier="lead" amount="2" />
+      <RequiredItem identifier="potassium" />
       <RequiredItem identifier="rubber" />
     </Fabricate>
     <Sprite texture="%ModDir%/Content/Items/Misc/Rod carrier.png" depth="0.54" sourcerect="1,2,149,86" origin="0.5,0.5" />
     <Body width="150" height="85" density="50" />
     <Holdable slots="RightHand+LeftHand" holdpos="0,-80" handle1="-30,14" handle2="30,14" aimable="false" msg="ItemMsgPickUpSelect">
-      <StatusEffect type="OnActive" target="Character" SpeedMultiplier="0.75" setvalue="true" />
+      <StatusEffect type="OnActive" target="Character" SpeedMultiplier="0.7" setvalue="true" />
     </Holdable>
     <!-- Only accept fuel rods -->
-    <ItemContainer autofill="False" hideitems="true" drawinventory="true" capacity="2" slotsperrow="3" maxstacksize="4" canbeselected="true" msg="ItemMsgInteractSelect" keepopenwhenequipped="true" movableframe="true">
-      <Containable items="fuelrod,thoriumfuelrod,fulguriumfuelrod,fulguriumfuelrodvolatile,ekutility_incendiumfuelrod,uraniumore,thorianite,depletedfuel,uranium,thorium" />
+    <ItemContainer autofill="False" capacity="4" slotsperrow="2" canbeselected="true" msg="ItemMsgInteractSelect" keepopenwhenequipped="true" movableframe="true">
+      <Containable items="fuelrod,thoriumfuelrod,fuelrod_active,thoriumfuelrod_active,fulguriumfuelrod,fulguriumfuelrodvolatile,ekutility_incendiumfuelrod,depletedfuel,uranium,thorium" />
     </ItemContainer>
   </Item>
-  <Item name="" identifier="fueltransportcylinder" tags="mediumitem,mobilecontainer,tool,hazardcontainement" description="" scale="0.5" linkable="true" pickdistance="150" impactsoundtag="impact_metal_heavy">
-    <PreferredContainer primary="reactorcab" minamount="1" maxamount="1" spawnprobability="1" />
-    <Price baseprice="400">
-      <Price storeidentifier="merchantoutpost" sold="false" />
-      <Price storeidentifier="merchantcity" minavailable="1" />
-      <Price storeidentifier="merchantresearch" sold="false" multiplier="1.25" />
-      <Price storeidentifier="merchantmilitary" sold="false" multiplier="1.25" />
-      <Price storeidentifier="merchantmine"  multiplier="1.25" />
-      <Price storeidentifier="merchantengineering" multiplier="1.4" minavailable="2" />
+
+<Override>
+  <!-- End Game item, a large movable storage for Fuel Rods or material -->
+  <Item name="" identifier="ekutility_handtruck_reactorfuel" category="Equipment" Tags="ekutility_compatiblefuelstorage,hazardcontainement" pickdistance="75" scale="0.6" description="">
+    <Price baseprice="500" buyingpricemultiplier="7" minleveldifficulty="65" soldbydefault="false" soldeverywhere="false" minavailable="0" maxavailable="1">
+      <Price storeidentifier="merchantmine" sold="true" minavailable="1" />
+      <Price storeidentifier="merchantengineering" sold="true" multiplier="2.5" />
     </Price>
     <Deconstruct time="10">
-      <Item identifier="titaniumaluminiumalloy" />
-      <Item identifier="lead" />
+      <Item identifier="du_p_alloy" amount="2" />
+      <Item identifier="lead" amount="3" />
+      <Item identifier="potassium" />
       <Item identifier="rubber" />
     </Deconstruct>
-    <Fabricate suitablefabricators="fabricator" requiredtime="15">
-      <RequiredSkill identifier="mechanical" level="25" />
-      <RequiredItem identifier="titaniumaluminiumalloy" />
-      <RequiredItem identifier="lead" />
-      <RequiredItem identifier="rubber" />
+    <Fabricate suitablefabricators="fabricator" requiredtime="120">
+      <RequiredSkill identifier="mechanical" level="65" />
+      <RequiredItem identifier="du_p_alloy" amount="3" />
+      <RequiredItem identifier="lead" amount="4" />
+      <RequiredItem identifier="potassium" amount="2" />
+      <RequiredItem identifier="rubber" amount="2"/>
+      <RequiredItem identifier="dementonite" amount="2" />
     </Fabricate>
-	<Sprite texture="%ModDir%/Content/Items/Misc/RodCylinderSpritesheet.png" depth="0.55" sourcerect="0,32,116,32" origin="0.5,0.5" />
-	<InventoryIcon texture="%ModDir%/Content/Items/Misc/RodCylinderInvSpritesheet.png" sourcerect="0,0,64,64" origin="0.5,0.5" />
-    <Body width="215" height="30" density="30" />
-    <Holdable slots="RightHand,LeftHand" holdpos="0,-50" handle1="-10,0" handle2="10,0" aimable="false" msg="ItemMsgPickUpUse" canbeselected="false" canbepicked="true" pickkey="Use">
-      <StatusEffect type="OnContained" target="Character" SpeedMultiplier="0.95" setvalue="true" />
+    <Sprite texture="%ModDir%/Content/Items/Misc/ekutility_containers.png" depth="0.54" sourcerect="0,624,160,224" origin="0.5,0.5" />
+    <Body width="136" height="208" density="25" />
+    <Holdable slots="RightHand+LeftHand" controlpose="true" holdpos="52,-82" holdangle="25" handle1="-54,86" handle2="-54,86" aimable="false" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnActive" target="Character" SpeedMultiplier="0.5" setvalue="true" />
     </Holdable>
-    <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Select">
-      <sprite name="Rod storage worn" texture="%ModDir%/Content/Items/Misc/RodCylinderSpritesheet.png" canbehiddenbyotherwearables="false" rotation="90" inheritlimbdepth="false" depth="0.6" sourcerect="0,32,116,32" origin="0.5,2" limb="Torso" ignorelimbscale="true" scale="0.5" />
-    </Wearable>
     <!-- Only accept fuel rods -->
-    <ItemContainer autofill="False" hideitems="true" drawinventory="true" capacity="1" slotsperrow="1" maxstacksize="1" canbeselected="true" msg="ItemMsgInteractSelect" keepopenwhenequipped="false" movableframe="false">
-      <Containable items="fuelrod,thoriumfuelrod,fulguriumfuelrod,fulguriumfuelrodvolatile,ekutility_incendiumfuelrod,depletedfuel" />
+    <ItemContainer autofill="False" capacity="12" slotsperrow="3" canbeselected="true" msg="ItemMsgInteractSelect" keepopenwhenequipped="true" movableframe="true">
+      <Containable items="fuelrod,thoriumfuelrod,fuelrod_active,thoriumfuelrod_active,fulguriumfuelrod,fulguriumfuelrodvolatile,ekutility_incendiumfuelrod,depletedfuel,uranium,thorium" />
     </ItemContainer>
   </Item>
+</Override>
+
   <!-- Cut content due to baro coding making the idea impossible -->
   <!--  <Item name="Stasis transport crate" identifier="stasiscrate" tags="crate,safe" description="A fuel transport crate reinforced with alien materials and equiped with a micro stasis generator to hold extremely hazardous materials no other container can handle. Does not protect contained item from impacts." scale="0.5" linkable="true" pickdistance="150" impactsoundtag="impact_metal_heavy">
       <Price baseprice="2500" >
@@ -76,13 +111,13 @@
       <Price locationtype="military" multiplier="1.1" minavailable="1" sold="false"/>
       <Price locationtype="mine" multiplier="1.3" minavailable="1" sold="false"/>
     </Price>
-	
+  
     <Deconstruct time="10">
       <Item identifier="steel" />
       <Item identifier="lead" />
       <Item identifier="rubber" />
     </Deconstruct>
-	
+  
     <Fabricate suitablefabricators="fabricator" requiredtime="230">
       <RequiredSkill identifier="mechanical" level="70" />
       <RequiredSkill identifier="electrical" level="40" />
@@ -97,13 +132,13 @@
       <RequiredItem identifier="stasisemitter" />
       <RequiredItem identifier="stasisemitter" />
     </Fabricate>
-	
+  
     <Sprite texture="Mods/Hazardous Reactors/Content/Items/Misc/stasis fuel crate.png" depth="0.54" sourcerect="1,2,149,86" origin="0.5,0.5" />
     <Body width="150" height="85" density="50" />
-	
+  
 <LightComponent range="350.0" lightcolor="40,180,40,255" powerconsumption="3" MinVoltage="0.99" IsOn="true" castshadows="true" allowingameediting="false" >
-			<Sprite texture="Content/Items/Tools/tools.png" sourcerect="410,1,19,68" depth="0.56" />
-			
+      <Sprite texture="Content/Items/Tools/tools.png" sourcerect="410,1,19,68" depth="0.56" />
+      
       <StatusEffect type="OnActive" target="Contained" targetslot="0" Condition="-0.5">
         <RequiredItem items="batterycell" type="Contained" />
       </StatusEffect>
@@ -113,61 +148,61 @@
       <StatusEffect type="OnActive" target="Contained" targetslot="0" Condition="-0.40">
         <RequiredItem excludedidentifiers="batterycell,fulguriumbatterycell" type="Contained" />
       </StatusEffect>
-	  
+    
       <StatusEffect type="OnActive" targettype="This" Voltage="1.0" setvalue="true" >
         <RequiredItem items="fulguriumbatterycell" type="Contained" />
       </StatusEffect>
-	  
+    
       <RequiredItems items="mobilebattery" targetslot="0" type="Contained" msg="ItemMsgBatteryCellRequired" />
 
 
-		 Give back condition equal to the condition loss to mimick a stasis effect 
-	  
-	  	 <StatusEffect type="Always" targetslot="1" targettype="contained" condition="2.5" delay="1" comparison="And">
+     Give back condition equal to the condition loss to mimick a stasis effect 
+    
+       <StatusEffect type="Always" targetslot="1" targettype="contained" condition="2.5" delay="1" comparison="And">
         <RequiredItem items="supercritical_incendium,supercritical_fulgurium" type="Contained" />
-	        <Conditional targetitemcomponent="lightcompnent" IsActive="true" />
+          <Conditional targetitemcomponent="lightcompnent" IsActive="true" />
       </StatusEffect>
-	  
-		 If out of power trigger the crisis rod effect 
+    
+     If out of power trigger the crisis rod effect 
 
-		<StatusEffect type="Always" disabledeltatime="true" stackable="false" target="This" comparaison="And">
-	        <Conditional IsActive="false" />
+    <StatusEffect type="Always" disabledeltatime="true" stackable="false" target="This" comparaison="And">
+          <Conditional IsActive="false" />
         <RequiredItem items="supercritical_incendium,supercritical_fulgurium" type="Contained" />
         <sound file="Content/Items/Tools/FlareLoop.ogg" range="800.0" loop="true" />
         <ParticleEmitter particle="ekflarelight1" emitinterval="2.1" particleamount="10" particlespersecond="25" anglemin="70" anglemax="100" velocitymin="100" velocitymax="200" scalemin="0.7" scalemax="0.7" />
         <ParticleEmitter particle="ekthermiteflare1" emitinterval="2.1" particleamount="10" particlespersecond="25" anglemin="70" anglemax="100" velocitymin="100" velocitymax="200" scalemin="0.7" scalemax="0.7" />
         <ParticleEmitter particle="FlareBubbles"  particlespersecond="40" anglemin="70" anglemax="100" velocitymin="100" velocitymax="200" scalemin="0.8" scalemax="1.2" />
       </StatusEffect>
-	  
+    
       <StatusEffect type="Always" disabledeltatime="true" stackable="false" delay="1" target="This" comparison="And" >
-	        <Conditional IsActive="false" />
+          <Conditional IsActive="false" />
         <RequiredItem items="supercritical_incendium,supercritical_fulgurium" type="Contained" />
-	  		<Explosion range="500" structuredamage="0" force="0.001" flames="false" sparks="false" shockwave="false" camerashake="0" ignorecover="false" smoke="false" flashrange="0" underwaterbubble="false" delay="1" stackable="false">
+        <Explosion range="500" structuredamage="0" force="0.001" flames="false" sparks="false" shockwave="false" camerashake="0" ignorecover="false" smoke="false" flashrange="0" underwaterbubble="false" delay="1" stackable="false">
           <Affliction identifier="criticalrod_burn_emitter" strength="50" />
         </Explosion>
-				<Explosion range="350" structuredamage="15" force="0.001" flames="false" sparks="false" shockwave="false" camerashake="0" ignorecover="false" smoke="false" flashrange="0" underwaterbubble="false" stackable="false"/>
+        <Explosion range="350" structuredamage="15" force="0.001" flames="false" sparks="false" shockwave="false" camerashake="0" ignorecover="false" smoke="false" flashrange="0" underwaterbubble="false" stackable="false"/>
       </StatusEffect>
-	
+  
     <Holdable slots="RightHand+LeftHand" holdpos="0,-80" handle1="-30,14" handle2="30,14" aimable="false" msg="ItemMsgPickUpSelect" >
-	<StatusEffect type="OnActive" target="Character" SpeedMultiplier="0.5" setvalue="true" />
+  <StatusEffect type="OnActive" target="Character" SpeedMultiplier="0.5" setvalue="true" />
     <StatusEffect type="Always" target="contained" condition="1.0" delay="1" stackable="false" />
-	</Holdable>
-	  
-		 If out of power trigger the molten rods effect 
-		
-		<StatusEffect type="Always" target="This" stackable="false" delay="0.5" comparison="And" >
+  </Holdable>
+    
+     If out of power trigger the molten rods effect 
+    
+    <StatusEffect type="Always" target="This" stackable="false" delay="0.5" comparison="And" >
         <RequiredItem items="molten_rods" type="Contained" />
-	        <Conditional IsActive="false" />
-				<Explosion range="1000" stun="0" force="0.01" smoke="false" flames="false" shockwave="false" sparks="false" underwaterbubble="false" camerashake="0.0" flash="false" flashRange="0" ignorecover="false">
-				<Affliction identifier="radiationsickness" strength="8" />
-		 </Explosion>
-			<sound file="Mods\Hazardous Reactors\Content\Items\Reactor\extremeradiation.ogg" type="OnUse" range="500.0" loop="true" volume="0.5" />
-			</StatusEffect>	
-			
-		</LightComponent>
-	
-		 Activation box
-	
+          <Conditional IsActive="false" />
+        <Explosion range="1000" stun="0" force="0.01" smoke="false" flames="false" shockwave="false" sparks="false" underwaterbubble="false" camerashake="0.0" flash="false" flashRange="0" ignorecover="false">
+        <Affliction identifier="radiationsickness" strength="8" />
+     </Explosion>
+      <sound file="Mods\Hazardous Reactors\Content\Items\Reactor\extremeradiation.ogg" type="OnUse" range="500.0" loop="true" volume="0.5" />
+      </StatusEffect>	
+      
+    </LightComponent>
+  
+     Activation box
+  
     <CustomInterface canbeselected="false" drawhudwhenequipped="true" allowuioverlap="true">
       <GuiFrame relativesize="0.16,0.15" anchor="CenterLeft" pivot="BottomLeft" relativeoffset="0.006,-0.05" style="ItemUI" />
       <TickBox text="Stasis generator on">
@@ -176,58 +211,22 @@
       </TickBox>
 
     </CustomInterface>
-			
-		Container, voltage 
-		
+      
+    Container, voltage 
+    
     <ItemContainer autofill="False" hideitems="true" drawinventory="true" capacity="2" slotsperrow="2" maxstacksize="1" canbeselected="true" msg="ItemMsgInteractSelect" keepopenwhenequipped="true" movableframe="true">
-	<SlotIcon slotindex="0" texture="Content/UI/WeaponUI.png" sourcerect="64,961,32,22" origin="0.5,0.45" />
-	
+  <SlotIcon slotindex="0" texture="Content/UI/WeaponUI.png" sourcerect="64,961,32,22" origin="0.5,0.45" />
+  
       <Containable items="supercritical_incendium,supercritical_fulgurium,molten_rods" />
-	  
+    
       <Containable items="fulguriumbatterycell" />
-	  
+    
        <Containable items="mobilebattery">
         <StatusEffect type="OnContaining" targettype="This" Voltage="1.0" setvalue="true" />
       </Containable>
 
     </ItemContainer>
-			
+      
   </Item> -->
-  <Override>
-    <Item name="" identifier="ekutility_handtruck_reactorfuel" category="Equipment" Tags="ekutility_compatiblefuelstorage,hazardcontainement" pickdistance="75" scale="0.6" description="">
-      <Price baseprice="300">
-      <Price storeidentifier="merchantoutpost" sold="false" />
-      <Price storeidentifier="merchantcity" minavailable="1" />
-      <Price storeidentifier="merchantresearch" sold="false" multiplier="1.25" />
-      <Price storeidentifier="merchantmilitary" sold="false" multiplier="1.25" />
-      <Price storeidentifier="merchantmine"  multiplier="1.25" />
-      <Price storeidentifier="merchantengineering" multiplier="1.4" minavailable="2" />
-    </Price>
-      <Deconstruct time="10">
-        <Item identifier="aluminium" />
-        <!--42-->
-        <Item identifier="lead" />
-        <!--18-->
-        <Item identifier="potassium" />
-        <!--10-->
-        <Item identifier="rubber" />
-        <!--20-->
-      </Deconstruct>
-      <Fabricate suitablefabricators="fabricator" requiredtime="15">
-        <RequiredSkill identifier="mechanical" level="25" />
-        <RequiredItem identifier="aluminium" />
-        <RequiredItem identifier="lead" />
-        <RequiredItem identifier="potassium" />
-        <RequiredItem identifier="rubber" />
-      </Fabricate>
-      <Sprite texture="%ModDir%/Content/Items/Misc/ekutility_containers.png" depth="0.54" sourcerect="0,624,160,224" origin="0.5,0.5" />
-      <Body width="136" height="208" density="25" />
-      <Holdable slots="RightHand+LeftHand" controlpose="true" holdpos="52,-82" holdangle="25" handle1="-54,86" handle2="-54,86" aimable="false" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="OnActive" target="Character" SpeedMultiplier="0.8" setvalue="true" />
-      </Holdable>
-      <ItemContainer autofill="False" hideitems="true" drawinventory="true" capacity="3" slotsperrow="3" maxstacksize="1" canbeselected="true" msg="ItemMsgInteractSelect" keepopenwhenequipped="true" movableframe="true">
-        <Containable identifiers="smallitem,fuelrod,reactorfuel" />
-      </ItemContainer>
-    </Item>
-  </Override>
+
 </Items>

--- a/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Misc/minerals.xml
+++ b/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Misc/minerals.xml
@@ -21,13 +21,13 @@
     <LightComponent lightcolor="160,175,187,225" range="100" powerconsumption="0" flicker="0.0" flickerspeed="0.5" pulsefrequency="0.4" pulseamount="0" ison="true" drawbehindsubs="true">
       <LightTexture texture="Content/Lights/pointlight_rays.png" origin="0.5,0.5" />
     </LightComponent>
-  <ContainedSprite texture="%ModDir%/Content/Items/Misc/IodineEnvironment.png" usewhenattached="true" decorativespritebehavior="HideWhenNotVisible" depth="0.55" sourcerect="86,0,83,99" origin="0.5,0.5" />
-  <Sprite texture="%ModDir%/Content/Items/Misc/IodineCrystal.png" depth="0.3" sourcerect="0,0,64,64" origin="0.5,0.5" />
-  <DecorativeSprite texture="%ModDir%/Content/Items/Misc/IodineEnvironment.png" depth="0.49" sourcerect="0,0,82,99" offset="20,0" randomrotation="-20,20" randomscale="0.8,1.5" randomoffset="30,30" origin="0.5,0.5" randomgroupid="1" />
-  <DecorativeSprite texture="%ModDir%/Content/Items/Misc/IodineEnvironment.png" depth="0.48" sourcerect="171,0,82,99" offset="20,0" randomrotation="-20,20" randomscale="0.8,1.5" randomoffset="30,30" origin="0.5,0.5" randomgroupid="1" />
-  <DecorativeSprite texture="%ModDir%/Content/Items/Misc/IodineEnvironment.png" depth="0.51" sourcerect="0,0,82,99" offset="-20,0" randomrotation="-20,20" randomscale="0.8,1.5" randomoffset="30,30" origin="0.5,0.5" randomgroupid="2" />
-  <DecorativeSprite texture="%ModDir%/Content/Items/Misc/IodineEnvironment.png" depth="0.52" sourcerect="171,0,82,99" offset="-20,0" randomrotation="-20,20" randomscale="0.8,1.5" randomoffset="30,30" origin="0.5,0.5" randomgroupid="2" />
-  <DecorativeSprite texture="%ModDir%/Content/Items/Misc/IodineCrystal.png" depth="0.4" sourcerect="0,0,64,64" offset="0,-40" randomrotation="-20,20" origin="0.5,0.5" />
+    <ContainedSprite texture="%ModDir%/Content/Items/Misc/IodineEnvironment.png" usewhenattached="true" decorativespritebehavior="HideWhenNotVisible" depth="0.55" sourcerect="86,0,83,99" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Content/Items/Misc/IodineCrystal.png" depth="0.3" sourcerect="0,0,64,64" origin="0.5,0.5" />
+    <DecorativeSprite texture="%ModDir%/Content/Items/Misc/IodineEnvironment.png" depth="0.49" sourcerect="0,0,82,99" offset="20,0" randomrotation="-20,20" randomscale="0.8,1.5" randomoffset="30,30" origin="0.5,0.5" randomgroupid="1" />
+    <DecorativeSprite texture="%ModDir%/Content/Items/Misc/IodineEnvironment.png" depth="0.48" sourcerect="171,0,82,99" offset="20,0" randomrotation="-20,20" randomscale="0.8,1.5" randomoffset="30,30" origin="0.5,0.5" randomgroupid="1" />
+    <DecorativeSprite texture="%ModDir%/Content/Items/Misc/IodineEnvironment.png" depth="0.51" sourcerect="0,0,82,99" offset="-20,0" randomrotation="-20,20" randomscale="0.8,1.5" randomoffset="30,30" origin="0.5,0.5" randomgroupid="2" />
+    <DecorativeSprite texture="%ModDir%/Content/Items/Misc/IodineEnvironment.png" depth="0.52" sourcerect="171,0,82,99" offset="-20,0" randomrotation="-20,20" randomscale="0.8,1.5" randomoffset="30,30" origin="0.5,0.5" randomgroupid="2" />
+    <DecorativeSprite texture="%ModDir%/Content/Items/Misc/IodineCrystal.png" depth="0.4" sourcerect="0,0,64,64" offset="0,-40" randomrotation="-20,20" origin="0.5,0.5" />
     <Body radius="40" width="20" density="50" />
     <LevelResource deattachduration="8" randomoffsetfromwall="80">
       <Commonness commonness="0.65" />
@@ -42,14 +42,15 @@
 
   <Item identifier="deconcontaminationemitter" hideinmenus="true">
     <Sprite texture="Content/Items/JobGear/TalentGear.png" sourcerect="0,0,2,2" depth="0.55" origin="0.5,0.5" />
+    <Body radius="1" width="1" density="10" />
     <ItemComponent>
       <!-- Contamination on Deconstruction-->
-      <StatusEffect type="OnSpawn" target="This" delay="0.1">
+      <StatusEffect type="OnSpawn" target="This" delay="0.1" checkconditionalalways="true">
+        <Conditional InWater="false" />
         <sound file="%ModDir%/Content/Items/Misc/rock.ogg" range="600" volume="0.8" />
-        <Explosion range="500" ignorecover="false" smoke="true" showeffects="false">
+        <Explosion range="500" force="0.001" ignorecover="false" showeffects="false" smoke="true">
           <Affliction identifier="contamination" strength="10" />
-          <Affliction identifier="radiationgeiger" strength="2" />
-          <Affliction identifier="burn" strength="0.1" />
+          <Affliction identifier="radiationgeiger" strength="3" />
         </Explosion>
       </StatusEffect>
       <!-- delete after explosion-->

--- a/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Reactor/Fuel rods.xml
+++ b/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Reactor/Fuel rods.xml
@@ -1,140 +1,177 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Items>
-  <Override>
 
-    <!-- STANDARD FUEL RODS -->
+<!-- STANDARD FUEL RODS -->
 
-    <Item name="" category="fuel" identifier="fuelrod" Tags="reactorfuel" maxstacksize="8" scale="0.5" health="100" impactsoundtag="impact_metal_light" description="">
-      <!-- Spawn location and pricing -->
-      <PreferredContainer primary="reactorcab" minamount="2" maxamount="5" spawnprobability="1" />
-      <PreferredContainer secondary="wreckreactorcab,abandonedstoragecab" minamount="1" maxamount="3" spawnprobability="1" />
-    <Price baseprice="150" displaynonempty="true" minavailable="2" maxavailable="4">
+<Override>
+
+  <!-- Fuel rods are now two different items -->
+  <!--
+    One Inactive item
+    One Active (Hazard) item
+
+    Inactive item will be switched for active item when:
+    Inside Items that uses them (Reactor or RFA)
+    ~~Upon taking damage?~~
+
+  -->
+
+  <!-- Uranium Fuel Rod (Inactive) -->
+  <Item name="" category="fuel" identifier="fuelrod" Tags="reactorfuel" maxstacksize="4" scale="0.5" health="90" impactsoundtag="impact_metal_light" description="">
+    <!-- Spawn/PrefContainer(Vanilla) & Store Availability-->
+    <PreferredContainer primary="reactorcab"/>
+    <PreferredContainer secondary="nucleargun" minamount="1" maxamount="1" spawnprobability="1"/>
+    <PreferredContainer secondary="wreckreactorcab,abandonedreactorcab" minamount="1" maxamount="2" spawnprobability="0.5"/>
+    <PreferredContainer secondary="beaconengcab" amount="1" spawnprobability="0.2"/>
+    <PreferredContainer secondary="abandonedengcab,wreckengcab" amount="1" spawnprobability="0.05"/>
+    <Price baseprice="100" displaynonempty="true" minavailable="1" maxavailable="5">
       <Price storeidentifier="merchantoutpost" />
-      <Price storeidentifier="merchantcity" minavailable="1" />
+      <Price storeidentifier="merchantcity" minavailable="3" />
       <Price storeidentifier="merchantresearch" />
       <Price storeidentifier="merchantmilitary" />
       <Price storeidentifier="merchantmine" />
-      <Price storeidentifier="merchantengineering" multiplier="0.9" minavailable="2" />
+      <Price storeidentifier="merchantengineering" multiplier="0.9" minavailable="3" />
     </Price>
-    
-      <!-- Crafting -->
-    
-    
-      <Deconstruct time="10">
-        <Item identifier="steel" />
-        <Item identifier="lead" />
-        <Item identifier="uranium" copycondition="true" />
-      </Deconstruct>
-      <Fabricate suitablefabricators="fabricator" requiredtime="15">
-        <RequiredSkill identifier="mechanical" level="25" />
-        <RequiredItem identifier="uranium" />
-        <RequiredItem identifier="steel" />
-        <RequiredItem identifier="lead" />
-      </Fabricate>
-    
-    
-      <!-- Recycle option currently cause problem, disabled until the devs fix it
-    
-    <Fabricate suitablefabricators="fabricator" displayname="recycleitem" requiredtime="10">
-      <RequiredSkill identifier="mechanical" level="15" />
-      <RequiredItem identifier="uranium" />
-      <RequiredItem identifier="fuelrod" mincondition="0.0" usecondition="false"/>
-    </Fabricate> -->
-    
-    
-      <!-- Texture and light -->
-    
-    
-      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="576,64,64,64" origin="0.5,0.5" />
-      <Sprite texture="Content/Items/Tools/tools.png" depth="0.55" sourcerect="410,1,19,68" />
-      <Body radius="6" height="55" density="20" />
-      <LightComponent range="350.0" lightcolor="40,180,40,255" powerconsumption="3" MinVoltage="0.99" IsOn="true" castshadows="true" allowingameediting="false">
-        <Sprite texture="Content/Items/Tools/tools.png" sourcerect="410,1,19,68" depth="0.56" />
-          <Conditional IsFullCondition="false" />
-      </LightComponent>
-    
-    
-      <!-- Active effect and other SE -->
-    
-    
-      <Holdable handle1="0,0" slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="Always" target="This" stackable="false" voltage="2">
-          <Conditional IsFullCondition="false" />
-        </StatusEffect>
-    
-        <StatusEffect type="OnContained" targettype="This,Character" targetlimbs="LeftHand,RightHand" disabledeltatime="true" delay="1" stackable="false">
-          <Conditional IsFullCondition="false" />
-            <Affliction identifier="radiationsickness" strength="4" />
-            <Affliction identifier="radiationgeiger" strength="4" />
-        </StatusEffect>
-    
-        <StatusEffect type="OnContained" targettype="This,Character" targetlimbs="LeftHand,RightHand" disabledeltatime="true" delay="0.5" stackable="false">
-          <Conditional IsFullCondition="false" />
-          <Affliction identifier="burningrod" strength="100" />
-        </StatusEffect>
-    
-        <StatusEffect type="InWater" target="This" comparison="And" CheckConditionalAlways="true" >
-          <ParticleEmitter particle="bubbles" anglemin="0" anglemax="360" particleamount="1" velocitymin="0" velocitymax="50" scalemin="1" scalemax="1" />
-          <ParticleEmitter particle="extinguisher" anglemin="0" anglemax="360" velocitymin="5.0" velocitymax="50.0" particlespersecond="40" />
-          <Conditional IsFullCondition="false" />
-        </StatusEffect>
-    
-        <StatusEffect type="OnNotContained" target="This" disabledeltatime="true" stackable="false" delay="1" comparison="And">
-          <Conditional IsFullCondition="false" />
-          <Conditional InWater="false" />
-          <Explosion range="1000" stun="0" force="0.001" smoke="false" flames="false" shockwave="false" sparks="false" underwaterbubble="false" camerashake="0.0" flash="false" flashRange="0" ignorecover="false">
-            <Affliction identifier="radiationsickness" strength="2.5" />
-            <Affliction identifier="radiationgeiger" strength="2.5" />
-            <Affliction identifier="hazardexposure" strength="10" />
-          </Explosion>
-        </StatusEffect>
-    
-        <StatusEffect type="OnContained" target="This" disabledeltatime="true" stackable="false" delay="1" comparison="And">
-          <Conditional IsFullCondition="false" />
-          <Conditional InWater="false" />
-          <Conditional hastag="neq hazardcontainement" targetcontainer="true" />
-          <Explosion range="1000" stun="0" force="0.001" smoke="false" flames="false" shockwave="false" sparks="false" underwaterbubble="false" camerashake="0.0" flash="false" flashRange="0" ignorecover="false">
-            <Affliction identifier="radiationsickness" strength="0.625" />
-            <Affliction identifier="radiationgeiger" strength="0.625" />
-            <Affliction identifier="hazardexposure" strength="10" />
-          </Explosion>
-        </StatusEffect>
-    
-        <StatusEffect type="OnNotContained" target="This" disabledeltatime="true" stackable="false" delay="4">
-          <Conditional IsFullCondition="false" />
-          <Fire />
-        </StatusEffect>
-    
-        <StatusEffect type="OnNotContained" targettype="This" disabledeltatime="true" delay="0.5" stackable="false" setvalue="true" condition="0.05">
-          <Conditional condition="lte 0.01" />
-        </StatusEffect>
-      </Holdable>
-    
-    
-      <!-- Allow rod to be used with fission accelerator -->
-    
-    
-      <ItemContainer hideitems="true" capacity="1" itemrotation="90" drawinventory="false" canbeselected="false" SpawnWithId="nucleargunbolt" removecontaineditemsondeconstruct="true" showcontainedstateindicator="false">
-        <Containable items="nucleargunbolt" />
-        <StatusEffect type="OnUse" target="This" condition="-10" disabledeltatime="true">
-          <SpawnItem identifiers="nucleargunbolt" spawnposition="ThisInventory" />
-        </StatusEffect>
-      </ItemContainer>
-      <Throwable characterusable="false" slots="Any,RightHand,LeftHand" throwforce="4.0" holdpos="0,0" handle1="0,0" msg="ItemMsgPickUpSelect" />
-  
+
+    <!-- Standard info-->
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="576,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" depth="0.55" sourcerect="410,1,19,68" />
+    <Body radius="6" height="55" density="20" />
     <Quality>
       <QualityStat stattype="Condition" value="0.1"/>
     </Quality>
-  
-    </Item>
-  </Override>
-  
-  
-  <Override>
-    <Item name="" category="fuel" identifier="thoriumfuelrod" Tags="reactorfuel" maxstacksize="8" cargocontaineridentifier="metalcrate" scale="0.5" health="300" impactsoundtag="impact_metal_light" description="">
-      <!-- Spawn location and pricing -->
-      <PreferredContainer primary="reactorcab" minamount="1" maxamount="2" spawnprobability="0.05" />
-      <PreferredContainer primary="wreckreactorcab,abandonedstoragecab" minamount="0" maxamount="2" spawnprobability="0.25" />
+
+    <!-- Slow Decon Time, create contamination hazard, gives lead if empty -->
+    <Deconstruct time="45">
+      <Item identifier="iron" />
+      <Item identifier="lead" maxcondition="0.10" />
+      <Item identifier="uranium" mincondition="0.95" />
+      <Item identifier="deconcontaminationemitter" />
+    </Deconstruct>
+
+    <!-- Cheaper Recipe, No Recycling (for now) -->
+    <Fabricate suitablefabricators="fabricator" requiredtime="15">
+      <RequiredSkill identifier="mechanical" level="25" />
+      <RequiredItem identifier="iron" />
+      <RequiredItem identifier="copper" />
+      <RequiredItem identifier="uranium" />
+    </Fabricate>
+
+    <!-- Holding/Throwing & Status Effect -->
+    <Throwable characterusable="false" slots="RightHand,LeftHand" throwforce="4.0" holdpos="0,0" handle1="0,0" msg="ItemMsgPickUpSelect">
+      <!-- Check every 5s, if not full condition spawn active rod?-->
+    </Throwable>
+  </Item>
+
+  <!-- Uranium Fuel Rod (Active) -->
+  <Item name="" hideinmenus="true" identifier="fuelrod_active" Tags="reactorfuel" maxstacksize="1" scale="0.5" health="90" impactsoundtag="impact_metal_light" description="">
+    <!-- Standard info-->
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="576,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" depth="0.55" sourcerect="410,1,19,68" />
+    <Body radius="6" height="55" density="20" />
+    <Quality>
+      <QualityStat stattype="Condition" value="0.1"/>
+    </Quality>
+    <!-- Allow rod to be used with fission accelerator -->
+    <ItemContainer hideitems="true" capacity="1" itemrotation="90" drawinventory="false" canbeselected="false" SpawnWithId="nucleargunbolt" removecontaineditemsondeconstruct="true" showcontainedstateindicator="false">
+      <Containable items="nucleargunbolt" />
+      <StatusEffect type="OnUse" target="This" condition="-10" disabledeltatime="true">
+        <SpawnItem identifiers="nucleargunbolt" spawnposition="ThisInventory" />
+      </StatusEffect>
+    </ItemContainer>
+
+    <!-- Slow Decon Time, create contamination hazard, gives lead if empty -->
+    <Deconstruct time="45">
+      <Item identifier="iron" />
+      <Item identifier="lead" maxcondition="0.10" />
+      <Item identifier="uranium" mincondition="0.95" />
+      <Item identifier="deconcontaminationemitter" />
+    </Deconstruct>
+
+    <!-- Holding/Throwing & Status Effect -->
+    <Throwable characterusable="false" slots="RightHand,LeftHand" throwforce="4.0" holdpos="0,0" handle1="0,0" msg="ItemMsgPickUpSelect">
+      <!-- TURNS ON THE RADIATION -->
+      <StatusEffect type="OnNotContained" target="This" IsOn="true"/>
+
+      <StatusEffect type="OnContained" target="This" IsOn="true">
+        <Conditional hastag="neq hazardcontainement" targetcontainer="true" />
+      </StatusEffect>
+
+      <!-- TURNS OFF THE RADIATION -->
+      <StatusEffect type="OnContained" target="This" IsOn="false">
+        <Conditional hastag="eq hazardcontainement" targetcontainer="true" />
+      </StatusEffect>
+
+      <!-- Burns whoever holds it -->
+      <StatusEffect type="OnContained" targettype="This,Character">
+        <Conditional IsOn="true" />
+        <Affliction identifier="burningrod" strength="300" />
+        <Affliction identifier="radiationsickness" strength="4" />
+        <Affliction identifier="radiationgeiger" strength="4" />
+      </StatusEffect>
+
+    </Throwable>
+
+    <!-- LETHAL LIGHT, ONLY ACTIVE WHEN NOT SAFELY CONTAINED-->
+    <LightComponent lightcolor="0,200,0,180" range="160" ison="true" castshadows="false">
+
+      <!-- Radiation Hazard! (When not in water) -->
+      <StatusEffect type="OnActive" target="This" interval="1" Condition="-0.3" disabledeltatime="true">
+        <Conditional InWater="false" />
+        <Explosion range="1000" force="0.001" ignorecover="false" showeffects="false" >
+          <Affliction identifier="radiationsickness" strength="4" />
+          <Affliction identifier="radiationgeiger" strength="4" />
+          <Affliction identifier="hazardexposure" strength="10" />
+        </Explosion>
+      </StatusEffect>
+
+      <!-- Radiation Hazard InWater! Range halved -->
+      <StatusEffect type="OnActive" target="This" interval="1" Condition="-0.3" disabledeltatime="true">
+        <Conditional InWater="true" />
+        <Explosion range="500" force="0.001" ignorecover="false" showeffects="false" >
+          <Affliction identifier="radiationsickness" strength="4" />
+          <Affliction identifier="radiationgeiger" strength="4" />
+          <Affliction identifier="hazardexposure" strength="10" />
+        </Explosion>
+      </StatusEffect>
+
+      <!-- Spawn fire! After 12s of not contained or in water -->
+      <StatusEffect type="OnActive" target="This" comparison="And" delay="12" stackable="false" checkconditionalalways="true">
+        <Conditional InWater="false" />
+        <Conditional IsOn="true" />
+        <Fire size="1.0"/>
+      </StatusEffect>
+
+      <!-- Visual Effects Warning Smoke after 6s -->
+      <StatusEffect type="OnActive" target="This" comparison="And" delay="6" checkconditionalalways="true">
+        <Conditional InWater="false" />
+        <Conditional IsOn="true" />
+        <ParticleEmitter particle="DarkSmoke" particleburstamount="3" particleburstinterval="0.5" particlespersecond="20" scalemin="2.5" scalemax="3.5" anglemin="50" anglemax="130" velocitymin="10" velocitymax="50"/>
+      </StatusEffect>
+
+      <!-- Visual Effects NotInWater, Smoke -->
+      <StatusEffect type="OnActive" target="This">
+        <Conditional InWater="false" />
+        <ParticleEmitter particle="swirlysmoke" colormultiplier="20,20,20,255" particlespersecond="5" scalemin="3" scalemax="8" anglemin="0" anglemax="360" velocitymin="0" velocitymax="10" />
+      </StatusEffect>
+
+      <!-- Visual Effects InWater, Bubbles and Steam-->
+      <StatusEffect type="OnActive" target="This">
+        <Conditional InWater="true" />
+        <ParticleEmitter particle="bubbles" anglemin="0" anglemax="360" emitinterval="0.07" particleamount="1" velocitymin="0" velocitymax="50" scalemin="1" scalemax="1" />
+        <ParticleEmitter particle="extinguisher" anglemin="0" anglemax="360" emitinterval="0.07" velocitymin="5.0" velocitymax="50.0" particlespersecond="40" />
+      </StatusEffect>
+
+    </LightComponent>
+  </Item>
+
+  <!-- Thorium Fuel Rod (Inactive) -->
+  <Item name="" category="fuel" identifier="thoriumfuelrod" Tags="reactorfuel" maxstacksize="8" cargocontaineridentifier="metalcrate" scale="0.5" health="300" impactsoundtag="impact_metal_light" description="">
+    <!-- Spawn/PrefContainer(Vanilla) & Store Availability-->
+    <PreferredContainer primary="reactorcab" />
+    <PreferredContainer secondary="wreckreactorcab,abandonedreactorcab" amount="1" spawnprobability="0.1"/>
+    <PreferredContainer secondary="beaconengcab" amount="1" spawnprobability="0.02"/>
+    <PreferredContainer secondary="abandonedengcab,wreckengcab" amount="1" spawnprobability="0.01"/>
     <Price baseprice="200" displaynonempty="true" maxavailable="2">
       <Price storeidentifier="merchantoutpost" sold="false" />
       <Price storeidentifier="merchantcity" minavailable="1" />
@@ -143,113 +180,143 @@
       <Price storeidentifier="merchantmine" sold="false" multiplier="1.25" />
       <Price storeidentifier="merchantengineering" multiplier="0.9" minavailable="2" />
     </Price>
-      <!-- Crafting -->
-      <Deconstruct time="10">
-        <Item identifier="steel" />
-        <Item identifier="lead" />
-        <Item identifier="thorium" copycondition="true" />
-      </Deconstruct>
-      <Fabricate suitablefabricators="fabricator" requiredtime="15">
-        <RequiredSkill identifier="mechanical" level="25" />
-        <RequiredItem identifier="thorium" />
-        <RequiredItem identifier="steel" />
-        <RequiredItem identifier="lead" />
-      </Fabricate>
-    
-    
-      <!-- Recycle option currently cause problem, disabled until the devs fix it
-    
-    <Fabricate suitablefabricators="fabricator" displayname="recycleitem" requiredtime="10">
-      <RequiredSkill identifier="mechanical" level="15" />
-      <RequiredItem identifier="thorium" />
-      <RequiredItem identifier="thoriumfuelrod" mincondition="0.0" usecondition="false"/>
-    </Fabricate> -->
-    
-    
-      <!-- Texture and light -->
-    
-    
-      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="384,64,64,64" origin="0.5,0.5" />
-      <Sprite texture="Content/Items/Tools/tools.png" depth="0.56" sourcerect="452,1,19,68" />
-      <Body radius="6" height="55" density="20" />
-      <LightComponent range="350.0" lightcolor="123,19,255,255" powerconsumption="3" MinVoltage="0.99" IsOn="true" castshadows="true" allowingameediting="false">
-        <Sprite texture="Content/Items/Tools/tools.png" sourcerect="452,1,19,68" depth="0.56" />
-          <Conditional IsFullCondition="false" />
-      </LightComponent>
-    
-    
-      <!-- Active effect and other SE -->
-    
-    
-      <Holdable handle1="0,0" slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect">
-        <StatusEffect type="Always" target="This" stackable="false" voltage="2">
-          <Conditional IsFullCondition="false" />
-        </StatusEffect>
-    
-        <StatusEffect type="OnContained" targettype="This,Character" targetlimbs="LeftHand,RightHand" disabledeltatime="true" delay="1" stackable="false">
-          <Conditional IsFullCondition="false" />
-          <Affliction identifier="burningrod" strength="100" />
-          <Affliction identifier="radiationsickness" strength="4" />
-          <Affliction identifier="radiationgeiger" strength="4" />
-        </StatusEffect>
-    
-        <StatusEffect type="InWater" target="This" comparison="And" CheckConditionalAlways="true" >
-          <ParticleEmitter particle="bubbles" anglemin="0" anglemax="360" particleamount="1" velocitymin="0" velocitymax="50" scalemin="1" scalemax="1" />
-          <ParticleEmitter particle="extinguisher" anglemin="0" anglemax="360" velocitymin="5.0" velocitymax="50.0" particlespersecond="40" />
-          <Conditional IsFullCondition="false" />
-        </StatusEffect>
-    
-        <StatusEffect type="OnNotContained" target="This" disabledeltatime="true" stackable="false" delay="1" comparison="And">
-          <Conditional IsFullCondition="false" />
-          <Conditional InWater="false" />
-          <Explosion range="1000" stun="0" force="0.001" smoke="false" flames="false" shockwave="false" sparks="false" underwaterbubble="false" camerashake="0.0" flash="false" flashRange="0" ignorecover="false">
-            <Affliction identifier="radiationsickness" strength="2.5" />
-            <Affliction identifier="radiationgeiger" strength="2.5" />
-            <Affliction identifier="hazardexposure" strength="10" />
-          </Explosion>
-        </StatusEffect>
-    
-        <StatusEffect type="OnContained" target="This" disabledeltatime="true" stackable="false" delay="1" comparison="And">
-          <Conditional IsFullCondition="false" />
-          <Conditional InWater="false" />
-          <Conditional hastag="neq hazardcontainement" targetcontainer="true" />
-          <Explosion range="1000" stun="0" force="0.001" smoke="false" flames="false" shockwave="false" sparks="false" underwaterbubble="false" camerashake="0.0" flash="false" flashRange="0" ignorecover="false">
-            <Affliction identifier="radiationsickness" strength="0.625" />
-            <Affliction identifier="radiationgeiger" strength="0.625" />
-            <Affliction identifier="hazardexposure" strength="10" />
-          </Explosion>
-        </StatusEffect>
-    
-        <StatusEffect type="OnNotContained" target="This" disabledeltatime="true" stackable="false" delay="4">
-          <Conditional IsFullCondition="false" />
-          <Fire />
-        </StatusEffect>
 
-        <StatusEffect type="OnNotContained" targettype="This" disabledeltatime="true" delay="0.5" stackable="false" setvalue="true" condition="0.05">
-          <Conditional condition="lte 0.01" />
-        </StatusEffect>
-      </Holdable>
-    
-    
-      <!-- Allow rod to be used with fission accelerator -->
-    
-    
-      <ItemContainer hideitems="true" capacity="1" itemrotation="90" drawinventory="false" canbeselected="false" SpawnWithId="nucleargunbolt" removecontaineditemsondeconstruct="true" showcontainedstateindicator="false">
-        <Containable items="nucleargunbolt" />
-        <StatusEffect type="OnUse" target="This" condition="-10.0" disabledeltatime="true">
-          <SpawnItem identifiers="nucleargunbolt" spawnposition="ThisInventory" />
-        </StatusEffect>
-      </ItemContainer>
-      <Throwable characterusable="false" slots="Any,RightHand,LeftHand" throwforce="4.0" holdpos="0,0" handle1="0,0" msg="ItemMsgPickUpSelect" />
-
+    <!-- Standard info-->
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="384,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" depth="0.56" sourcerect="452,1,19,68" />
+    <Body radius="6" height="55" density="20" />
     <Quality>
       <QualityStat stattype="Condition" value="0.1"/>
     </Quality>
+
+    <!-- Slow Decon Time, create contamination hazard, gives extra lead if empty -->
+    <Deconstruct time="45">
+      <Item identifier="steel" />
+      <Item identifier="lead" maxcondition="0.10" />
+      <Item identifier="thorium" mincondition="0.95" />
+      <Item identifier="deconcontaminationemitter" />
+    </Deconstruct>
+
+    <!-- Cheaper Recipe, No Recycling (for now) -->
+    <Fabricate suitablefabricators="fabricator" requiredtime="15">
+      <RequiredSkill identifier="mechanical" level="35" />
+      <RequiredItem identifier="steel" />
+      <RequiredItem identifier="copper" />
+      <RequiredItem identifier="thorium" />
+    </Fabricate>
+
+    <!-- Holding/Throwing & Status Effect -->
+    <Throwable characterusable="false" slots="RightHand,LeftHand" throwforce="4.0" holdpos="0,0" handle1="0,0" msg="ItemMsgPickUpSelect">
+      <!-- Check every 5s, if not full condition spawn active rod?-->
+    </Throwable>
+  </Item>
+
+  <!-- Thorium Fuel Rod (Active) -->
+  <Item name="" hideinmenus="true" identifier="thoriumfuelrod_active" Tags="reactorfuel" maxstacksize="1" scale="0.5" health="300" impactsoundtag="impact_metal_light" description="">
+    <!-- Standard info-->
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="384,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" depth="0.56" sourcerect="452,1,19,68" />
+    <Body radius="6" height="55" density="20" />
+    <Quality>
+      <QualityStat stattype="Condition" value="0.1"/>
+    </Quality>
+    <!-- Allow rod to be used with fission accelerator -->
+    <ItemContainer hideitems="true" capacity="1" itemrotation="90" drawinventory="false" canbeselected="false" SpawnWithId="nucleargunbolt" removecontaineditemsondeconstruct="true" showcontainedstateindicator="false">
+      <Containable items="nucleargunbolt" />
+      <StatusEffect type="OnUse" target="This" condition="-10" disabledeltatime="true">
+        <SpawnItem identifiers="nucleargunbolt" spawnposition="ThisInventory" />
+      </StatusEffect>
+    </ItemContainer>
+
+    <!-- Slow Decon Time, create contamination hazard, gives extra lead if empty -->
+    <Deconstruct time="45">
+      <Item identifier="steel" />
+      <Item identifier="lead" maxcondition="0.10" />
+      <Item identifier="thorium" mincondition="0.95" />
+      <Item identifier="deconcontaminationemitter" />
+    </Deconstruct>
+
+    <!-- Holding/Throwing & Status Effect -->
+    <Throwable characterusable="false" slots="RightHand,LeftHand" throwforce="4.0" holdpos="0,0" handle1="0,0" msg="ItemMsgPickUpSelect">
+      <!-- TURNS ON THE RADIATION -->
+      <StatusEffect type="OnNotContained" target="This" IsOn="true"/>
+
+      <StatusEffect type="OnContained" target="This" IsOn="true">
+        <Conditional hastag="neq hazardcontainement" targetcontainer="true" />
+      </StatusEffect>
+
+      <!-- TURNS OFF THE RADIATION -->
+      <StatusEffect type="OnContained" target="This" IsOn="false">
+        <Conditional hastag="eq hazardcontainement" targetcontainer="true" />
+      </StatusEffect>
+
+      <!-- Burns whoever holds it -->
+      <StatusEffect type="OnContained" targettype="This,Character">
+        <Conditional IsOn="true" />
+        <Affliction identifier="burningrod" strength="300" />
+        <Affliction identifier="radiationsickness" strength="3" />
+        <Affliction identifier="radiationgeiger" strength="3" />
+      </StatusEffect>
+
+    </Throwable>
+
+    <!-- LETHAL LIGHT, ONLY ACTIVE WHEN NOT SAFELY CONTAINED-->
+    <LightComponent lightcolor="26, 0, 219,180" range="160" ison="true" castshadows="false">
+
+      <!-- Radiation Hazard! (When not in water) -->
+      <StatusEffect type="OnActive" target="This" interval="1" Condition="-0.3" disabledeltatime="true">
+        <Conditional InWater="false" />
+        <Explosion range="1000" force="0.001" ignorecover="false" showeffects="false" >
+          <Affliction identifier="radiationsickness" strength="2.5" />
+          <Affliction identifier="radiationgeiger" strength="2.5" />
+          <Affliction identifier="hazardexposure" strength="10" />
+        </Explosion>
+      </StatusEffect>
+
+      <!-- Radiation Hazard InWater! Range halved -->
+      <StatusEffect type="OnActive" target="This" interval="1" Condition="-0.3" disabledeltatime="true">
+        <Conditional InWater="true" />
+        <Explosion range="500" force="0.001" ignorecover="false" showeffects="false" >
+          <Affliction identifier="radiationsickness" strength="2.5" />
+          <Affliction identifier="radiationgeiger" strength="2.5" />
+          <Affliction identifier="hazardexposure" strength="10" />
+        </Explosion>
+      </StatusEffect>
+
+      <!-- Spawn fire! After 15s of not contained or in water -->
+      <StatusEffect type="OnActive" target="This" comparison="And" delay="15" stackable="false" checkconditionalalways="true">
+        <Conditional InWater="false" />
+        <Conditional IsOn="true" />
+        <Fire size="1.0"/>
+      </StatusEffect>
+
+      <!-- Visual Effects Warning Smoke after 9s -->
+      <StatusEffect type="OnActive" target="This" comparison="And" delay="9" checkconditionalalways="true">
+        <Conditional InWater="false" />
+        <Conditional IsOn="true" />
+        <ParticleEmitter particle="DarkSmoke" particleburstamount="3" particleburstinterval="0.5" particlespersecond="20" scalemin="2.5" scalemax="3.5" anglemin="50" anglemax="130" velocitymin="10" velocitymax="50"/>
+      </StatusEffect>
+
+      <!-- Visual Effects NotInWater, Smoke -->
+      <StatusEffect type="OnActive" target="This">
+        <Conditional InWater="false" />
+        <ParticleEmitter particle="swirlysmoke" colormultiplier="20,20,20,255" particlespersecond="5" scalemin="3" scalemax="8" anglemin="0" anglemax="360" velocitymin="0" velocitymax="10" />
+      </StatusEffect>
+
+      <!-- Visual Effects InWater, Bubbles and Steam-->
+      <StatusEffect type="OnActive" target="This">
+        <Conditional InWater="true" />
+        <ParticleEmitter particle="bubbles" anglemin="0" anglemax="360" emitinterval="0.07" particleamount="1" velocitymin="0" velocitymax="50" scalemin="1" scalemax="1" />
+        <ParticleEmitter particle="extinguisher" anglemin="0" anglemax="360" emitinterval="0.07" velocitymin="5.0" velocitymax="50.0" particlespersecond="40" />
+      </StatusEffect>
+
+    </LightComponent>
+  </Item>
+
+</Override>
   
-    </Item>
-  </Override>
-  
-  
+
+<!--"53,2,207,180" purple radiation should be reserved for volatile?-->
   <!-- ALIEN FUEL RODS -->
   
   

--- a/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Reactor/OutpostItems.xml
+++ b/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Reactor/OutpostItems.xml
@@ -71,7 +71,7 @@
       </StatusEffect>
       <!-- REACTOR "DRY" EXPLOSION WITH ANY FUEL CONTAINED -->
       <StatusEffect type="OnBroken" target="This" FissionRate="0.0" disabledeltatime="true" stackable="false">
-        <RequiredItem items="fuelrod,fulguriumfuelrod,thoriumfuelrod,ekutility_incendiumfuelrod,fulguriumfuelrodvolatile" type="Contained" />
+        <RequiredItem items="fuelrod_active,fulguriumfuelrod,thoriumfuelrod_active,ekutility_incendiumfuelrod,fulguriumfuelrodvolatile" type="Contained" />
         <Conditional InWater="false" />
         <Explosion range="1000" structuredamage="100" force="10.0" camerashake="300" flashrange="10000" flashduration="5" screencolor="255,255,255,255" screencolorrange="5000" screencolorduration="3.0">
           <Affliction identifier="burn" strength="200" />
@@ -84,7 +84,7 @@
       </StatusEffect>
       <!-- URANIUM/THORIUM MELTDOWN EFFECT -->
       <StatusEffect type="OnBroken" target="This" FissionRate="0.0" disabledeltatime="true" stackable="false">
-        <RequiredItem items="fuelrod,thoriumfuelrod" type="Contained" />
+        <RequiredItem items="fuelrod_active,thoriumfuelrod_active" type="Contained" />
         <Conditional InWater="false" />
         <Explosion range="3000" structuredamage="0" force="10" flames="false" sparks="false" shockwave="false" camerashake="0" smoke="false" flashrange="0" flashduration="0" ignorecover="true">
           <Affliction identifier="radiationsickness" strength="400" />
@@ -154,7 +154,7 @@
       </StatusEffect>
       <!-- MOLTEN RODS SPAWN EFFECT -->
       <StatusEffect type="OnBroken" target="this" delay="1" comparison="And">
-        <RequiredItem items="fuelrod,thoriumfuelrod" type="Contained" />
+        <RequiredItem items="fuelrod_active,thoriumfuelrod_active" type="Contained" />
         <Conditional InWater="false" />
         <SpawnItem identifier="molten_rods" spawnposition="ThisInventory" />
       </StatusEffect>
@@ -247,7 +247,7 @@
         <sound file="Content/Items/Reactor/ReactorOverheatAlarm.ogg" type="OnUse" range="10000.0" loop="true" volume="1.0" />
         <Conditional condition="lte 25" />
         <Conditional condition="gt 15" />
-        <RequiredItem items="fuelrod,fulguriumfuelrod,thoriumfuelrod,ekutility_incendiumfuelrod,fulguriumfuelrodvolatile" type="Contained" />
+        <RequiredItem items="fuelrod_active,fulguriumfuelrod,thoriumfuelrod_active,ekutility_incendiumfuelrod,fulguriumfuelrodvolatile" type="Contained" />
       </StatusEffect>
       <StatusEffect type="Always" target="This" comparison="And" condition="-0.6">
         <ParticleEmitter particle="smoke" particleburstamount="6" particleburstinterval="0.5" particlespersecond="2" scalemin="1" scalemax="2.5" anglemin="0" anglemax="359" velocitymin="-50" velocitymax="50" mincondition="15.0" maxcondition="50.0" underwaterbubble="false" />
@@ -256,7 +256,7 @@
         <Conditional condition="lte 15" />
         <Conditional condition="gt 0" />
         <Fire size="1" />
-        <RequiredItem items="fuelrod,fulguriumfuelrod,thoriumfuelrod,ekutility_incendiumfuelrod,fulguriumfuelrodvolatile" type="Contained" />
+        <RequiredItem items="fuelrod_active,fulguriumfuelrod,thoriumfuelrod_active,ekutility_incendiumfuelrod,fulguriumfuelrodvolatile" type="Contained" />
       </StatusEffect>
       <!-- STEAM VISUAL + SOUND EFFECTS -->
       <StatusEffect type="Always" target="This" comparison="And">
@@ -319,14 +319,35 @@
     </ConnectionPanel>
     <!-- FUEL HEAT PRODUCTION -->
     <ItemContainer capacity="4" maxstacksize="1" canbeselected="true" hudpos="0.5,0.15" slotsperrow="1" uilabel="FuelRods">
+
+      <!--Uranium Fuel Rod Switch-->
       <Containable items="fuelrod">
+        <StatusEffect type="OnContaining" target="Contained">
+          <Remove />
+        </StatusEffect>
+        <StatusEffect type="OnContaining" target="This" delay="0.1" stackable="false">
+          <SpawnItem identifiers="fuelrod_active" spawnposition="ThisInventory" spawnifinventoryfull="true"/>
+        </StatusEffect>
+      </Containable>
+
+      <!--Thorium Fuel Rod Switch-->
+      <Containable items="thoriumfuelrod">
+        <StatusEffect type="OnContaining" target="Contained">
+          <Remove />
+        </StatusEffect>
+        <StatusEffect type="OnContaining" target="This" delay="0.1" stackable="false">
+          <SpawnItem identifiers="thoriumfuelrod_active" spawnposition="ThisInventory" spawnifinventoryfull="true"/>
+        </StatusEffect>
+      </Containable>
+
+      <Containable items="fuelrod_active">
         <StatusEffect type="OnContaining" target="This" AvailableFuel="80" disabledeltatime="true" />
+      </Containable>
+      <Containable items="thoriumfuelrod_active">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="100.0" disabledeltatime="true" />
       </Containable>
       <Containable items="fulguriumfuelrod">
         <StatusEffect type="OnContaining" target="This" AvailableFuel="70.0" disabledeltatime="true" />
-      </Containable>
-      <Containable items="thoriumfuelrod">
-        <StatusEffect type="OnContaining" target="This" AvailableFuel="100.0" disabledeltatime="true" />
       </Containable>
       <Containable items="ekutility_incendiumfuelrod">
         <StatusEffect type="OnContaining" target="This" AvailableFuel="200.0" disabledeltatime="true" />
@@ -353,7 +374,7 @@
       <ParticleEmitter particle="heavysmoke" particleburstinterval="0.25" particlespersecond="2" scalemin="2.5" scalemax="5.0" mincondition="0.0" maxcondition="15.0" />
       <!-- WITH NON FULG ROD CONTAINED -->
       <StatusEffect type="OnFailure" target="this" Condition="-5">
-        <RequiredItem items="fuelrod,thoriumfuelrod,ekutility_incendiumfuelrod" type="Contained" />
+        <RequiredItem items="fuelrod_active,thoriumfuelrod_active,ekutility_incendiumfuelrod" type="Contained" />
         <Sound file="Content/Items/Weapons/IncendiumGrenade.ogg" range="1000" />
         <Explosion range="250" structuredamage="0" force="10" flames="false" sparks="true" shockwave="true" camerashake="0" ignorecover="false" smoke="true" flashrange="200" flashduration="2">
           <Affliction identifier="internaldamage" strength="10" />
@@ -382,7 +403,7 @@
       </StatusEffect>
       <!-- WITH URANIUM/THORIUM ROD CONTAINED -->
       <StatusEffect type="OnFailure" target="this">
-        <RequiredItem items="fuelrod,thoriumfuelrod" type="Contained" />
+        <RequiredItem items="fuelrod_active,thoriumfuelrod_active" type="Contained" />
         <Explosion range="1000" structuredamage="0" force="10" flames="false" sparks="true" shockwave="true" camerashake="0" ignorecover="false" smoke="false" flashrange="200" flashduration="2">
           <Affliction identifier="radiationsickness" strength="80" />
           <Affliction identifier="radiationgeiger" strength="80" />

--- a/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Reactor/reactor.xml
+++ b/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Reactor/reactor.xml
@@ -69,7 +69,7 @@
       </StatusEffect>
       <!-- REACTOR "DRY" EXPLOSION WITH ANY FUEL CONTAINED -->
       <StatusEffect type="OnBroken" target="This" FissionRate="0.0" disabledeltatime="true" stackable="false">
-        <RequiredItem items="fuelrod,fulguriumfuelrod,thoriumfuelrod,ekutility_incendiumfuelrod,fulguriumfuelrodvolatile" type="Contained" />
+        <RequiredItem items="fuelrod_active,fulguriumfuelrod,thoriumfuelrod_active,ekutility_incendiumfuelrod,fulguriumfuelrodvolatile" type="Contained" />
         <Conditional InWater="false" />
         <Explosion range="1000" structuredamage="100" force="10.0" camerashake="300" flashrange="10000" flashduration="5" screencolor="255,255,255,255" screencolorrange="5000" screencolorduration="3.0">
           <Affliction identifier="burn" strength="200" />
@@ -82,7 +82,7 @@
       </StatusEffect>
       <!-- URANIUM/THORIUM MELTDOWN EFFECT -->
       <StatusEffect type="OnBroken" target="This" FissionRate="0.0" disabledeltatime="true" stackable="false">
-        <RequiredItem items="fuelrod,thoriumfuelrod" type="Contained" />
+        <RequiredItem items="fuelrod_active,thoriumfuelrod_active" type="Contained" />
         <Conditional InWater="false" />
         <Explosion range="3000" structuredamage="0" force="10" flames="false" sparks="false" shockwave="false" camerashake="0" smoke="false" flashrange="0" flashduration="0" ignorecover="true">
           <Affliction identifier="radiationsickness" strength="400" />
@@ -152,7 +152,7 @@
       </StatusEffect>
       <!-- MOLTEN RODS SPAWN EFFECT -->
       <StatusEffect type="OnBroken" target="this" delay="1" comparison="And">
-        <RequiredItem items="fuelrod,thoriumfuelrod" type="Contained" />
+        <RequiredItem items="fuelrod_active,thoriumfuelrod_active" type="Contained" />
         <Conditional InWater="false" />
         <SpawnItem identifier="molten_rods" spawnposition="ThisInventory" />
       </StatusEffect>
@@ -245,7 +245,7 @@
         <sound file="Content/Items/Reactor/ReactorOverheatAlarm.ogg" type="OnUse" range="10000.0" loop="true" volume="1.0" />
         <Conditional condition="lte 25" />
         <Conditional condition="gt 15" />
-        <RequiredItem items="fuelrod,fulguriumfuelrod,thoriumfuelrod,ekutility_incendiumfuelrod,fulguriumfuelrodvolatile" type="Contained" />
+        <RequiredItem items="fuelrod_active,fulguriumfuelrod,thoriumfuelrod_active,ekutility_incendiumfuelrod,fulguriumfuelrodvolatile" type="Contained" />
       </StatusEffect>
       <StatusEffect type="Always" target="This" comparison="And" condition="-0.6">
         <ParticleEmitter particle="smoke" particleburstamount="6" particleburstinterval="0.5" particlespersecond="2" scalemin="1" scalemax="2.5" anglemin="0" anglemax="359" velocitymin="-50" velocitymax="50" mincondition="15.0" maxcondition="50.0" underwaterbubble="false" />
@@ -254,7 +254,7 @@
         <Conditional condition="lte 15" />
         <Conditional condition="gt 0" />
         <Fire size="1" />
-        <RequiredItem items="fuelrod,fulguriumfuelrod,thoriumfuelrod,ekutility_incendiumfuelrod,fulguriumfuelrodvolatile" type="Contained" />
+        <RequiredItem items="fuelrod_active,fulguriumfuelrod,thoriumfuelrod_active,ekutility_incendiumfuelrod,fulguriumfuelrodvolatile" type="Contained" />
       </StatusEffect>
       <!-- STEAM VISUAL + SOUND EFFECTS -->
       <StatusEffect type="Always" target="This" comparison="And">
@@ -320,14 +320,35 @@
     </ConnectionPanel>
     <!-- FUEL HEAT PRODUCTION -->
     <ItemContainer capacity="4" maxstacksize="1" canbeselected="true" hudpos="0.5,0.15" slotsperrow="1" uilabel="FuelRods">
+
+      <!--Uranium Fuel Rod Switch-->
       <Containable items="fuelrod">
+        <StatusEffect type="OnContaining" target="Contained">
+          <Remove />
+        </StatusEffect>
+        <StatusEffect type="OnContaining" target="This" delay="0.1" stackable="false">
+          <SpawnItem identifiers="fuelrod_active" spawnposition="ThisInventory" spawnifinventoryfull="true"/>
+        </StatusEffect>
+      </Containable>
+
+      <!--Thorium Fuel Rod Switch-->
+      <Containable items="thoriumfuelrod">
+        <StatusEffect type="OnContaining" target="Contained">
+          <Remove />
+        </StatusEffect>
+        <StatusEffect type="OnContaining" target="This" delay="0.1" stackable="false">
+          <SpawnItem identifiers="thoriumfuelrod_active" spawnposition="ThisInventory" spawnifinventoryfull="true"/>
+        </StatusEffect>
+      </Containable>
+
+      <Containable items="fuelrod_active">
         <StatusEffect type="OnContaining" target="This" AvailableFuel="80" disabledeltatime="true" />
+      </Containable>
+      <Containable items="thoriumfuelrod_active">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="100.0" disabledeltatime="true" />
       </Containable>
       <Containable items="fulguriumfuelrod">
         <StatusEffect type="OnContaining" target="This" AvailableFuel="70.0" disabledeltatime="true" />
-      </Containable>
-      <Containable items="thoriumfuelrod">
-        <StatusEffect type="OnContaining" target="This" AvailableFuel="100.0" disabledeltatime="true" />
       </Containable>
       <Containable items="ekutility_incendiumfuelrod">
         <StatusEffect type="OnContaining" target="This" AvailableFuel="200.0" disabledeltatime="true" />
@@ -354,7 +375,7 @@
       <ParticleEmitter particle="heavysmoke" particleburstinterval="0.25" particlespersecond="2" scalemin="2.5" scalemax="5.0" mincondition="0.0" maxcondition="15.0" />
       <!-- WITH NON FULG ROD CONTAINED -->
       <StatusEffect type="OnFailure" target="this" Condition="-5">
-        <RequiredItem items="fuelrod,thoriumfuelrod,ekutility_incendiumfuelrod" type="Contained" />
+        <RequiredItem items="fuelrod_active,thoriumfuelrod_active,ekutility_incendiumfuelrod" type="Contained" />
         <Sound file="Content/Items/Weapons/IncendiumGrenade.ogg" range="1000" />
         <Explosion range="250" structuredamage="0" force="10" flames="false" sparks="true" shockwave="true" camerashake="0" ignorecover="false" smoke="true" flashrange="200" flashduration="2">
           <Affliction identifier="internaldamage" strength="10" />
@@ -383,7 +404,7 @@
       </StatusEffect>
       <!-- WITH URANIUM/THORIUM ROD CONTAINED -->
       <StatusEffect type="OnFailure" target="this">
-        <RequiredItem items="fuelrod,thoriumfuelrod" type="Contained" />
+        <RequiredItem items="fuelrod_active,thoriumfuelrod_active" type="Contained" />
         <Explosion range="1000" structuredamage="0" force="10" flames="false" sparks="true" shockwave="true" camerashake="0" ignorecover="false" smoke="false" flashrange="200" flashduration="2">
           <Affliction identifier="radiationsickness" strength="80" />
           <Affliction identifier="radiationgeiger" strength="80" />

--- a/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Weapons/GeigerCounter.xml
+++ b/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Weapons/GeigerCounter.xml
@@ -24,24 +24,24 @@
       <StatusEffect type="Always" target="This" comparison="And">
         <Conditional Condition="neq 100" />
         <Conditional Condition="gte 80" />
-        <sound file="%ModDir%/Content/Items/Reactor/lowradiation.ogg" range="500.0" loop="true" volume="0.5" />
+        <sound file="%ModDir%/Content/Items/Reactor/lowradiation.ogg" range="500.0" loop="true" volume="0.5" dontmuffle="true" />
       </StatusEffect>
       <!-- Med Rad 21-50 -->
       <StatusEffect type="Always" target="This" comparison="And">
         <Conditional Condition="lt 80" />
         <Conditional Condition="gte 50" />
-        <sound file="%ModDir%/Content/Items/Reactor/mediumradiation.ogg" range="500.0" loop="true" volume="0.5" />
+        <sound file="%ModDir%/Content/Items/Reactor/mediumradiation.ogg" range="500.0" loop="true" volume="0.5" dontmuffle="true" />
       </StatusEffect>
       <!-- High Rad 51-80 -->
       <StatusEffect type="Always" target="This" comparison="And">
         <Conditional Condition="lt 50" />
         <Conditional Condition="gte 20" />
-        <sound file="%ModDir%/Content/Items/Reactor/highradiation.ogg" range="500.0" loop="true" volume="0.5" />
+        <sound file="%ModDir%/Content/Items/Reactor/highradiation.ogg" range="500.0" loop="true" volume="0.5" dontmuffle="true" />
       </StatusEffect>
       <!-- Lethal Rad 80+ -->
       <StatusEffect type="Always" target="This" comparison="And">
         <Conditional Condition="lt 20" />
-        <sound file="%ModDir%/Content/Items/Reactor/extremeradiation.ogg" range="500.0" loop="true" volume="0.5" />
+        <sound file="%ModDir%/Content/Items/Reactor/extremeradiation.ogg" range="500.0" loop="true" volume="0.5" dontmuffle="true" />
       </StatusEffect>
 
     </Holdable>

--- a/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Weapons/Weapons.xml
+++ b/Hazardous Reactors [ Lethal radiation update  ]/Content/Items/Weapons/Weapons.xml
@@ -189,66 +189,88 @@
       </Projectile>
     </Item>
   </Override>
-  <Override>
-    <Item name="" identifier="nucleargun" category="Equipment" cargocontaineridentifier="metalcrate" tags="mediumitem,mobilebattery,electrical,weapon,gun" Scale="0.5" impactsoundtag="impact_metal_heavy">
-      <PreferredContainer primary="secarmcab,weaponholder" />
-      <Price baseprice="675" soldeverywhere="false">
-        <Price locationtype="outpost" multiplier="1.5" sold="false" />
-        <Price locationtype="city" multiplier="1.25" sold="false" />
-        <Price locationtype="research" multiplier="1.25" sold="false" />
-        <Price locationtype="military" multiplier="0.9" sold="false" />
-        <Price locationtype="mine" multiplier="1.25" sold="false" />
-      </Price>
-      <Deconstruct time="10">
-        <Item identifier="fpgacircuit" />
-        <Item identifier="lead" />
-        <Item identifier="titaniumaluminiumalloy" />
-        <Item identifier="titaniumaluminiumalloy" />
-        <Item identifier="fulgurium" />
-      </Deconstruct>
-      <Fabricate suitablefabricators="fabricator" requiredtime="70" requiresrecipe="true">
-        <RequiredSkill identifier="electrical" level="65" />
-        <RequiredItem identifier="fpgacircuit" />
-        <RequiredItem identifier="lead" />
-        <RequiredItem identifier="titaniumaluminiumalloy" />
-        <RequiredItem identifier="titaniumaluminiumalloy" />
-        <RequiredItem identifier="fulgurium" />
-      </Fabricate>
-      <Sprite texture="Content/Items/JobGear/TalentGear.png" sourcerect="271,127,240,66" depth="0.55" origin="0.5,0.5" />
-      <Body width="238" height="63" density="70" />
-      <Holdable slots="RightHand+LeftHand" controlpose="true" holdpos="60,-15" aimpos="70,4" handle1="-50,-10" handle2="10,-3" holdangle="-25" />
-      <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Select">
-        <sprite name="Nuclear Gun Worn" texture="Content/Items/JobGear/TalentGear.png" canbehiddenbyotherwearables="false" rotation="90" inheritlimbdepth="false" depth="0.6" sourcerect="270,127,240,66" limb="Torso" scale="0.5" origin="0.5,0.8" />
-      </Wearable>
-      <RangedWeapon reload="0.25" holdtrigger="true" barrelpos="118,14" spread="0" unskilledspread="10" combatPriority="80" drawhudwhenequipped="true" crosshairscale="0.2" maxchargetime="0.75">
-        <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
-        <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
-        <ParticleEmitter particle="FlareBubbles" scalemin="1.4" scalemax="1.8" particleamount="14" anglemin="0" anglemax="360" velocitymin="0" velocitymax="50" />
-        <ParticleEmitter particle="GlowDot" scalemin="4.0" scalemax="4.0" particleamount="20" anglemin="0" anglemax="360" velocitymin="0" velocitymax="0" colormultiplier="10,235,195,255" />
-        <ParticleEmitterCharge particle="chargenucleargun" particlespersecond="60" scalemultiplier="0.75,0.75" scalemin="1.0" scalemax="1.0" anglemin="0" anglemax="359" />
-        <Sound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAccelerator.ogg" type="OnUse" range="3000" selectionmode="Random" />
-        <Sound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAccelerator2.ogg" type="OnUse" range="3000" />
-        <Sound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAccelerator3.ogg" type="OnUse" range="3000" />
-        <Sound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAccelerator4.ogg" type="OnUse" range="3000" />
-        <ChargeSound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAcceleratorStartLoop.ogg" range="3000" />
-        <StatusEffect type="OnUse">
-          <Explosion range="250.0" force="5" shockwave="false" smoke="false" flash="true" sparks="false" flames="false" underwaterbubble="false" camerashake="12.0" />
+
+<Override>
+  <Item name="" identifier="nucleargun" category="Equipment" cargocontaineridentifier="metalcrate" tags="mediumitem,mobilebattery,electrical,weapon,gun" Scale="0.5" impactsoundtag="impact_metal_heavy">
+    <PreferredContainer primary="secarmcab,weaponholder" />
+    <Price baseprice="675" soldeverywhere="false">
+      <Price locationtype="outpost" multiplier="1.5" sold="false" />
+      <Price locationtype="city" multiplier="1.25" sold="false" />
+      <Price locationtype="research" multiplier="1.25" sold="false" />
+      <Price locationtype="military" multiplier="0.9" sold="false" />
+      <Price locationtype="mine" multiplier="1.25" sold="false" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="fpgacircuit" />
+      <Item identifier="lead" />
+      <Item identifier="titaniumaluminiumalloy" />
+      <Item identifier="titaniumaluminiumalloy" />
+      <Item identifier="fulgurium" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="70" requiresrecipe="true">
+      <RequiredSkill identifier="electrical" level="65" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="lead" />
+      <RequiredItem identifier="titaniumaluminiumalloy" />
+      <RequiredItem identifier="titaniumaluminiumalloy" />
+      <RequiredItem identifier="fulgurium" />
+    </Fabricate>
+    <Sprite texture="Content/Items/JobGear/TalentGear.png" sourcerect="271,127,240,66" depth="0.55" origin="0.5,0.5" />
+    <Body width="238" height="63" density="70" />
+    <Holdable slots="RightHand+LeftHand" controlpose="true" holdpos="60,-15" aimpos="70,4" handle1="-50,-10" handle2="10,-3" holdangle="-25" />
+    <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Select">
+      <sprite name="Nuclear Gun Worn" texture="Content/Items/JobGear/TalentGear.png" canbehiddenbyotherwearables="false" rotation="90" inheritlimbdepth="false" depth="0.6" sourcerect="270,127,240,66" limb="Torso" scale="0.5" origin="0.5,0.8" />
+    </Wearable>
+    <RangedWeapon reload="0.25" holdtrigger="true" barrelpos="118,14" spread="0" unskilledspread="10" combatPriority="80" drawhudwhenequipped="true" crosshairscale="0.2" maxchargetime="0.75">
+      <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
+      <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
+      <ParticleEmitter particle="FlareBubbles" scalemin="1.4" scalemax="1.8" particleamount="14" anglemin="0" anglemax="360" velocitymin="0" velocitymax="50" />
+      <ParticleEmitter particle="GlowDot" scalemin="4.0" scalemax="4.0" particleamount="20" anglemin="0" anglemax="360" velocitymin="0" velocitymax="0" colormultiplier="10,235,195,255" />
+      <ParticleEmitterCharge particle="chargenucleargun" particlespersecond="60" scalemultiplier="0.75,0.75" scalemin="1.0" scalemax="1.0" anglemin="0" anglemax="359" />
+      <Sound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAccelerator.ogg" type="OnUse" range="3000" selectionmode="Random" />
+      <Sound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAccelerator2.ogg" type="OnUse" range="3000" />
+      <Sound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAccelerator3.ogg" type="OnUse" range="3000" />
+      <Sound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAccelerator4.ogg" type="OnUse" range="3000" />
+      <ChargeSound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAcceleratorStartLoop.ogg" range="3000" />
+      <StatusEffect type="OnUse">
+        <Explosion range="250.0" force="5" shockwave="false" smoke="false" flash="true" sparks="false" flames="false" underwaterbubble="false" camerashake="12.0" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="Contained">
+        <Use />
+      </StatusEffect>
+      <RequiredItems items="reactorfuel" type="Contained" msg="ItemMsgAmmoRequired" />
+      <RequiredSkill identifier="weapons" level="25" />
+    </RangedWeapon>
+    <ItemContainer itemrotation="90" capacity="1" maxstacksize="1" hideitems="false" itempos="10,-5" containedspritedepth="0.56" containedstateindicatorstyle="tank">
+      <Containable items="reactorfuel" />
+
+      <!--Uranium Fuel Rod Switch-->
+      <Containable items="fuelrod">
+        <StatusEffect type="OnContaining" target="Contained">
+          <Remove />
         </StatusEffect>
-        <StatusEffect type="OnUse" target="Contained">
-          <Use />
+        <StatusEffect type="OnContaining" target="This" delay="0.1" stackable="false">
+          <SpawnItem identifiers="fuelrod_active" spawnposition="ThisInventory" spawnifinventoryfull="true"/>
         </StatusEffect>
-        <RequiredItems items="reactorfuel" type="Contained" msg="ItemMsgAmmoRequired" />
-        <RequiredSkill identifier="weapons" level="25" />
-      </RangedWeapon>
-      <ItemContainer itemrotation="90" capacity="1" maxstacksize="1" hideitems="false" itempos="10,-5" containedspritedepth="0.56" containedstateindicatorstyle="tank">
-        <Containable items="reactorfuel" />
-      </ItemContainer>
-      <aitarget sightrange="3000" soundrange="5000" fadeouttime="5" />
-      <Quality>
-        <QualityStat stattype="FirepowerMultiplier" value="0.1" />
-      </Quality>
-    </Item>
-  </Override>
+      </Containable>
+
+      <!--Thorium Fuel Rod Switch-->
+      <Containable items="thoriumfuelrod">
+        <StatusEffect type="OnContaining" target="Contained">
+          <Remove />
+        </StatusEffect>
+        <StatusEffect type="OnContaining" target="This" delay="0.1" stackable="false">
+          <SpawnItem identifiers="thoriumfuelrod_active" spawnposition="ThisInventory" spawnifinventoryfull="true"/>
+        </StatusEffect>
+      </Containable>
+
+    </ItemContainer>
+    <aitarget sightrange="3000" soundrange="5000" fadeouttime="5" />
+    <Quality>
+      <QualityStat stattype="FirepowerMultiplier" value="0.1" />
+    </Quality>
+  </Item>
+</Override>
   <Item name="fulguriumgunbolt" identifier="fulguriumgunbolt" category="Misc" scale="0.5" sonarsize="2" hideinmenus="true">
     <Sprite texture="Content/Items/Weapons/weapons_new.png" sourcerect="143,414,113,9" depth="0.55" />
     <Body width="170" height="10" density="20" />


### PR DESCRIPTION
Fuel rods, Crates, Fuel truck has their inventory increased

Fueltruck is now a late game item, with a costly recipe and expanded inventory

Fuel rod has been reworked into a passive and active item

It get turned into an active item when inside of a reactor or RFA

Active fuel rod cannot be stacked anymore

Fuel rods now have a 50% decrease in range once in water and starts fire slower
